### PR TITLE
feat(plugin): add globbing support for from option (fixes #7)

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "homepage": "https://github.com/kevlened/copy-webpack-plugin",
   "dependencies": {
     "bluebird": "^2.10.2",
+    "glob": "^6.0.4",
     "lodash": "^3.10.1",
     "minimatch": "^3.0.0",
     "node-dir": "^0.1.10"

--- a/test/index.js
+++ b/test/index.js
@@ -176,6 +176,24 @@ describe('apply function', function() {
       .catch(done);
     });
 
+    it('can use an glob to move a file to the root directory', function(done) {
+      runEmit({
+        patterns: [{ from: path.join(HELPER_DIR, '*.txt') }],
+        expectedAssetKeys: ['file.txt']
+      })
+      .then(done)
+      .catch(done);
+    });
+
+    it('can use an glob to move multiple files to the root directory', function(done) {
+      runEmit({
+        patterns: [{ from: path.join(HELPER_DIR, '**/*.txt') }],
+        expectedAssetKeys: ['file.txt', 'directory/directoryfile.txt', 'directory/nested/nestedfile.txt']
+      })
+      .then(done)
+      .catch(done);
+    });
+
     it('can move a file to a new directory without a forward slash', function(done) {
       runEmit({
         patterns: [{ from: 'file.txt', to: 'newdirectory' }],
@@ -418,7 +436,7 @@ describe('apply function', function() {
       .catch(done);
     });
   });
-  
+
   describe('options', function() {
     describe('ignore', function() {
       it('ignores files when from is a file', function(done) {


### PR DESCRIPTION
Tried to avoid any breaking change for now.

In my opinion, it could be worth it to release a new breaking major after that only deals with globbing with both `cwd` and `base` options (like gulp/vinyl).