### PR TITLE
Support lodash v4.0.0

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,7 +35,7 @@ function apply(patterns, opts, compiler) {
       var relSrc = pattern.from;
       var absSrc = path.resolve(baseDir, relSrc);
       var relDest = pattern.to || '';
-      
+
       var forceWrite = !!pattern.force;
 
       return fs.statAsync(absSrc)
@@ -45,12 +45,12 @@ function apply(patterns, opts, compiler) {
       .then(function(stat) {
         if (stat && stat.isDirectory()) {
           contextDependencies.push(absSrc);
-          
+
           // Make the relative destination actually relative
           if (path.isAbsolute(relDest)) {
             relDest = path.relative(baseDir, relDest);
           }
-          
+
           return writeDirectoryToAssets({
             compilation: compilation,
             absDirSrc: absSrc,
@@ -63,7 +63,7 @@ function apply(patterns, opts, compiler) {
 
           return globAsync(relSrc, {cwd: baseDir})
           .each(function(relFileSrc) {
-                 
+
             // Skip if it matches any of our ignore list
             if (shouldIgnore(relFileSrc, ignoreList)) {
               return;
@@ -74,7 +74,7 @@ function apply(patterns, opts, compiler) {
             var relFileDirname = path.dirname(relFileSrc);
 
             fileDependencies.push(absFileSrc);
-            
+
             if (!stat && relFileDirname !== baseDir) {
               if (path.isAbsolute(relFileSrc)) {
                 // If the file is in a subdirectory (from globbing), we should correctly map the dest folder
@@ -87,7 +87,7 @@ function apply(patterns, opts, compiler) {
             } else {
               relFileDest = relFileDest || path.basename(relFileSrc);
             }
-            
+
             // Make the relative destination actually relative
             if (path.isAbsolute(relFileDest)) {
               relFileDest = path.relative(baseDir, relFileDest);
@@ -116,14 +116,14 @@ function apply(patterns, opts, compiler) {
   compiler.plugin("after-emit", function(compilation, cb) {
     var trackedFiles = compilation.fileDependencies;
     _.each(fileDependencies, function(file) {
-      if (!_.contains(trackedFiles, file)) {
+      if (!_.includes(trackedFiles, file)) {
         trackedFiles.push(file);
       }
     });
 
     var trackedDirs = compilation.contextDependencies;
     _.each(contextDependencies, function(context) {
-      if (!_.contains(trackedDirs, context)) {
+      if (!_.includes(trackedDirs, context)) {
         trackedDirs.push(context);
       }
     });
@@ -197,7 +197,7 @@ function shouldIgnore(pathName, ignoreList) {
     var params = {
       matchBase: true
     };
-    
+
     var glob;
     if (_.isString(g)) {
       glob = g;
@@ -208,7 +208,7 @@ function shouldIgnore(pathName, ignoreList) {
     } else {
       glob = '';
     }
-    
+
     return minimatch(pathName, glob, params);
   });
   if (matched) {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "bluebird": "^2.10.2",
     "fs-extra": "^0.26.4",
     "glob": "^6.0.4",
-    "lodash": "^3.10.1",
+    "lodash": "^4.3.0",
     "minimatch": "^3.0.0",
     "node-dir": "^0.1.10"
   },


### PR DESCRIPTION
This adds support for lodash 4.0 which has breaking changes and replaces `_.contains` with `_.includes` per [Changelog](https://github.com/lodash/lodash/wiki/Changelog#jan-12-2016--diff--docs)