### PR TITLE
Add the possibility to define a pattern specific context

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,10 @@ A pattern looks like:
     - is optional
     - defaults to `false`
     - forces the plugin to overwrite files staged by previous plugins
+* `context`
+    - is optional
+    - is a pattern specific context
+    - overrides the base context
 
 #### Available options:
 * `ignore`

--- a/index.js
+++ b/index.js
@@ -19,7 +19,7 @@ function toLooksLikeDirectory(pattern) {
 
 function apply(patterns, opts, compiler) {
 
-  var baseDir = compiler.options.context;
+  var globalBaseDir = compiler.options.context;
   var fileDependencies = [];
   var contextDependencies = [];
   var lastGlobalUpdate = 0;
@@ -33,6 +33,7 @@ function apply(patterns, opts, compiler) {
   compiler.plugin('emit', function(compilation, cb) {
     Promise.each(patterns, function(pattern) {
       var relSrc = pattern.from;
+      var baseDir = pattern.context || globalBaseDir;
       var absSrc = path.resolve(baseDir, relSrc);
       var relDest = pattern.to || '';
       


### PR DESCRIPTION
Hi there,

For one of my projects I needed to be able to specify a pattern specific context and this is why I added that new optional parameter.

My usecase is the following:
I want to copy html files from the app directory but at the same time copy fonts from one of my vendor node_modules folder.

Example:

`new CopyWebpackPlugin([
      {
        context: path.join(__dirname, 'app'),
        from: "**/*.html"
      },
      {
        context: path.join(__dirname, 'node_modules/ionic-framework'),
        from: "fonts/*.ttf"
      }
    ])`