### PR TITLE
remove platform specific separators from compilation.asset keys, fixes #29

### DIFF
--- a/index.js
+++ b/index.js
@@ -138,6 +138,8 @@ function writeFileToAssets(opts) {
   var absFileSrc = opts.absFileSrc;
   var forceWrite = opts.forceWrite;
   var lastGlobalUpdate = opts.lastGlobalUpdate;
+  //make sure that asset keys use fwd slashes
+  var relFileDest = relFileDest.replace(/\\/g, "/");
 
   if (compilation.assets[relFileDest] && !forceWrite) {
     return Promise.resolve();

--- a/test/index.js
+++ b/test/index.js
@@ -71,7 +71,11 @@ describe('apply function', function() {
     .then(function(compilation) {
       if (opts.expectedAssetKeys && opts.expectedAssetKeys.length > 0) {
         // Replace all paths with platform-specific paths
-        var expectedAssetKeys = _.map(opts.expectedAssetKeys, path.normalize);
+        // Replace all paths with platform-specific paths
+        // due to #29 we can't do that, as webpack compilation assets expects
+        // the keys with fwd slashes only --
+        //var expectedAssetKeys = _.map(opts.expectedAssetKeys, path.normalize);
+        var expectedAssetKeys = opts.expectedAssetKeys;
         expect(compilation.assets).to.have.all.keys(expectedAssetKeys);
       } else {
         expect(compilation.assets).to.be.empty;


### PR DESCRIPTION
Proposed PR to fix the compilation.asset keys handling for paths on windows as described in #29. 