### PR TITLE
Fix TypeError when working with webpack-dev-server

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -24,13 +24,13 @@ const getOutputDir = (compiler) => {
         return compiler.options.output.path;
     }
 
-    const outputPath = compiler.options.devServer.outputPath;
+    const devServer = compiler.options.devServer;
 
-    if (!outputPath || outputPath === '/') {
+    if (!devServer || !devServer.outputPath || devServer.outputPath === '/') {
         throw new Error('CopyWebpackPlugin: to use webpack-dev-server, devServer.outputPath must be defined in the webpack config');
     }
 
-    return outputPath;
+    return devServer.outputPath;
 };
 
 export default (patterns = [], options = {}) => {


### PR DESCRIPTION
webpack version 1.12.12 + webpack-dev-server 1.14.1

Seems like `compiler.options.devServer` is **undefined** when user doesn't defined `devServer` in webpack config

it will throw `TypeError: Cannot read property 'outputPath' of undefined`  at function `getOutputDir()`

So the customized error won't be thrown out