### PR TITLE
Fix ERROR in Path must be a string. Received undefined

### DIFF
--- a/src/toLooksLikeDirectory.js
+++ b/src/toLooksLikeDirectory.js
@@ -2,7 +2,7 @@ import _ from 'lodash';
 import path from 'path';
 
 export default (pattern) => {
-    const filename = pattern.to;
+    const filename = pattern.to || '';
 
     return pattern.toType !== 'file' && (
         path.extname(filename) === '' ||


### PR DESCRIPTION
node 6.0.0 + webpack 1.12.12

to reproduce this error, simply provide a file path in `from ` and omit `to`

like this in webpack config
`plugins: [
    new CopyWebpackPlugin([{ from: 'src/static/index.html' }]),
  ],`