### PR TITLE
refactor(index): export as prop and default

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -33,7 +33,7 @@ const getOutputDir = (compiler) => {
     return devServer.outputPath;
 };
 
-export default (patterns = [], options = {}) => {
+export function CopyWebpackPlugin (patterns = [], options = {}) {
     if (!_.isArray(patterns)) {
         throw new Error('CopyWebpackPlugin: patterns must be an array');
     }
@@ -237,3 +237,5 @@ export default (patterns = [], options = {}) => {
         apply
     };
 };
+
+export default CopyWebpackPlugin;


### PR DESCRIPTION
there was a breaking change in the recent patch. This change allows for destructuring 
https://github.com/AngularClass/angular2-webpack-starter/issues/585
`const CopyWebpackPlugin = require('copy-webpack-plugin').CopyWebpackPlugin`
`const {CopyWebpackPlugin} = require('copy-webpack-plugin')`
`const CopyWebpackPlugin = require('copy-webpack-plugin').default`


you can also support all imports via 
```typescript
function CopyWebpackPlugin () { /* ... */}
CopyWebpackPlugin['default'] = CopyWebpackPlugin;
// commonjs
export = CopyWebpackPlugin;
```

`const CopyWebpackPlugin = require('copy-webpack-plugin').CopyWebpackPlugin`
`const {CopyWebpackPlugin} = require('copy-webpack-plugin')`
`const CopyWebpackPlugin = require('copy-webpack-plugin').default`
`const CopyWebpackPlugin = require('copy-webpack-plugin')`
`import CopyWebpackPlugin from 'copy-webpack-plugin'`
`import {CopyWebpackPlugin} from 'copy-webpack-plugin'`
`import * as CopyWebpackPlugin from 'copy-webpack-plugin'`
