### PR TITLE
Don't write to filesystem directly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 3.0.0 (May 14, 2016)
+
+BREAKING CHANGE
+
+* No longer writing to filesystem when webpack-dev-server is running
+  Use the [write-file-webpack-plugin](https://www.npmjs.com/package/write-file-webpack-plugin) to force writing files to the filesystem
+
 ## 2.1.6 (May 14, 2016)
 
 * Readded Node v6.0.0 compatibility after finding root cause

--- a/README.md
+++ b/README.md
@@ -67,8 +67,8 @@ var path = require('path');
 module.exports = {
     context: path.join(__dirname, 'app'),
     devServer: {
-        // This is required for webpack-dev-server. The path should 
-        // be an absolute path to your build destination.
+        // This is required for webpack-dev-server if using a version <3.0.0.
+        // The path should be an absolute path to your build destination.
         outputPath: path.join(__dirname, 'build')
     },
     plugins: [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "copy-webpack-plugin",
-  "version": "2.1.6",
+  "version": "3.0.0",
   "description": "Copy files and directories in webpack",
   "main": "dist/index.js",
   "repository": {

--- a/src/writeDirectoryToAssets.js
+++ b/src/writeDirectoryToAssets.js
@@ -16,7 +16,7 @@ export default (opts) => {
     const forceWrite = opts.forceWrite;
     const ignoreList = opts.ignoreList;
     const copyUnmodified = opts.copyUnmodified;
-    const lastGlobalUpdate = opts.lastGlobalUpdate;
+    const writtenAssetHashes = opts.writtenAssetHashes;
 
     return dir.filesAsync(absDirSrc)
         .map((absFileSrc) => {
@@ -46,8 +46,8 @@ export default (opts) => {
                 compilation,
                 copyUnmodified,
                 forceWrite,
-                lastGlobalUpdate,
-                relFileDest
+                relFileDest,
+                writtenAssetHashes
             });
         });
 };

--- a/tests/index.js
+++ b/tests/index.js
@@ -132,8 +132,6 @@ describe('apply function', () => {
             options: opts.options,
             patterns: opts.patterns
         })
-        // mtime is only measured in whole seconds
-        .delay(1000)
         .then(() => {
             // Change a file
             fs.appendFileSync(opts.newFileLoc1, 'extra');


### PR DESCRIPTION
Remove dependence on special devServer config. Rely on [write-file-webpack-plugin](https://github.com/gajus/write-file-webpack-plugin) to write directly to filesystem when running devServer (if desired)